### PR TITLE
Rename setSimState()->setGradientWithSimState() and reorder params.

### DIFF
--- a/src/Train/Fortius.cpp
+++ b/src/Train/Fortius.cpp
@@ -173,7 +173,7 @@ void Fortius::setLoad(double loadWatts)
 }
 
 // Resistance in newtons when implementing 'slope' mode
-void Fortius::setSimState(double resistanceNewtons, double speedKph, double gradient)
+void Fortius::setGradientWithSimState(double gradient, double resistanceNewtons, double speedKph)
 {
     Lock lock(pvars);
     this->resistanceNewtons = resistanceNewtons;

--- a/src/Train/Fortius.h
+++ b/src/Train/Fortius.h
@@ -97,7 +97,7 @@ public:
 
     // SET
     void setLoad(double load);                  // set the load to generate in ERGOMODE
-    void setSimState(double resistanceNewtons, double speedKph, double gradient); // set the load to generate in SSMODE
+    void setGradientWithSimState(double gradient, double resistanceNewtons, double speedKph); // set the load to generate in SSMODE
     void setBrakeCalibrationFactor(double calibrationFactor); // Impacts relationship between brake setpoint and load
     void setPowerScaleFactor(double calibrationFactor);       // Scales output power, so user can adjust to match hub or crank power meter
     void setMode(int mode);

--- a/src/Train/FortiusController.cpp
+++ b/src/Train/FortiusController.cpp
@@ -139,9 +139,9 @@ FortiusController::setLoad(double load)
 }
 
 void
-FortiusController::setSimState(double resistanceNewtons, double speedKph, double gradient)
+FortiusController::setGradientWithSimState(double gradient, double resistanceNewtons, double speedKph)
 {
-    myFortius->setSimState(resistanceNewtons, speedKph, gradient);
+    myFortius->setGradientWithSimState(gradient, resistanceNewtons, speedKph);
 }
 
 void

--- a/src/Train/FortiusController.h
+++ b/src/Train/FortiusController.h
@@ -48,7 +48,7 @@ public:
     void getRealtimeData(RealtimeData &rtData);
     void pushRealtimeData(RealtimeData &rtData);
     void setLoad(double);
-    void setSimState(double, double, double) override;
+    void setGradientWithSimState(double, double, double) override;
     void setMode(int);
     void setWeight(double);
 };

--- a/src/Train/RealtimeController.h
+++ b/src/Train/RealtimeController.h
@@ -107,7 +107,7 @@ private:
     // not be called by simulation loop.
     virtual void setGradient(double) { return; }
 public:
-    virtual void setSimState(double, double, double gradient) { setGradient(gradient); }
+    virtual void setGradientWithSimState(double gradient, double, double) { setGradient(gradient); }
     virtual void setMode(int) { return; }
     virtual void setWindSpeed(double) { return; }
     virtual void setWeight(double) { return; }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -2114,7 +2114,7 @@ void TrainSidebar::loadUpdate()
         if (slope == -100) {
             Stop(DEVICE_OK);
         } else {
-            foreach(int dev, activeDevices) Devices[dev].controller->setSimState(resistanceNewtons, displaySpeed, slope);
+            foreach(int dev, activeDevices) Devices[dev].controller->setGradientWithSimState(slope, resistanceNewtons, displaySpeed);
             context->notifySetNow(displayWorkoutDistance * 1000);
         }
     }
@@ -2161,7 +2161,7 @@ void TrainSidebar::toggleCalibration()
                 if (calibrationDeviceIndex == dev) {
                     Devices[dev].controller->setCalibrationState(CALIBRATION_STATE_IDLE);
                     Devices[dev].controller->setMode(RT_MODE_SPIN);
-                    Devices[dev].controller->setSimState(resistanceNewtons, displaySpeed, slope);
+                    Devices[dev].controller->setGradientWithSimState(slope, resistanceNewtons, displaySpeed);
                 }
             }
         }
@@ -2191,7 +2191,7 @@ void TrainSidebar::toggleCalibration()
                 if (status&RT_MODE_ERGO)
                     Devices[dev].controller->setLoad(0);
                 else
-                    Devices[dev].controller->setSimState(0, 0, 0);
+                    Devices[dev].controller->setGradientWithSimState(0, 0, 0);
 
 
                 Devices[dev].controller->setMode(RT_MODE_CALIBRATE);
@@ -2575,7 +2575,7 @@ void TrainSidebar::Higher()
         if (status&RT_MODE_ERGO)
             foreach(int dev, activeDevices) Devices[dev].controller->setLoad(load);
         else
-            foreach(int dev, activeDevices) Devices[dev].controller->setSimState(resistanceNewtons, displaySpeed, slope);
+            foreach(int dev, activeDevices) Devices[dev].controller->setGradientWithSimState(slope, resistanceNewtons, displaySpeed);
     }
 
     emit setNotification(tr("Increasing intensity.."), 2);
@@ -2601,7 +2601,7 @@ void TrainSidebar::Lower()
         if (status&RT_MODE_ERGO)
             foreach(int dev, activeDevices) Devices[dev].controller->setLoad(load);
         else
-            foreach(int dev, activeDevices) Devices[dev].controller->setSimState(resistanceNewtons, displaySpeed, slope);
+            foreach(int dev, activeDevices) Devices[dev].controller->setGradientWithSimState(slope, resistanceNewtons, displaySpeed);
     }
 
     emit setNotification(tr("Decreasing intensity.."), 2);


### PR DESCRIPTION
 Increases clarity

- Fallback from setGradientWithSimState() to setGradient() is now really obviously a dropping of "WithSimState".
- until there is a unified interface for setLoad/Gradient, if one makes sense, setGradient...() is still the fundamental operation