### PR TITLE
Encapsulate control and telemetry variables

### DIFF
--- a/src/Train/Fortius.cpp
+++ b/src/Train/Fortius.cpp
@@ -389,6 +389,7 @@ void Fortius::run()
                 // speed
 
                 cur.SpeedMS = qFromLittleEndian<quint16>(&buf[32]) / s_deviceSpeedFactorMS;
+                cur.SmoothSpeedMS.update(cur.SpeedMS);
 
                 // Power is torque * wheelspeed - adjusted by device resistance factor.
                 cur.ForceNewtons = qFromLittleEndian<qint16>(&buf[38]) / s_newtonsToResistanceFactor;
@@ -589,7 +590,7 @@ int Fortius::sendRunCommand(double deviceSpeedMS, int16_t pedalSensor)
 
         // My modelled device limit (TBD)
         forceN = MattipeeForceLimit(deviceSpeedMS, forceN);
-        //forceN = MattipeeForceLimit(smoothSpeedMS.get(), forceN);
+        //forceN = MattipeeForceLimit(SmoothSpeedMS.get(), forceN);
 
         return forceN;
     };

--- a/src/Train/Fortius.h
+++ b/src/Train/Fortius.h
@@ -227,7 +227,7 @@ private:
         int    Buttons;       // Button status
         int    Steering;      // Steering angle
 
-        NSampleSmoothing<10> smoothSpeedMS;
+        NSampleSmoothing<10> SmoothSpeedMS;
     } _device; // must acquire pvars for read/write
 
     // OUTBOUND COMMANDS read & write requires lock since written by gui() thread

--- a/src/Train/FortiusController.h
+++ b/src/Train/FortiusController.h
@@ -66,9 +66,6 @@ public:
 private:
     uint8_t  calibrationState = CALIBRATION_STATE_IDLE;
     NSampleSmoothing<100> calibration_values;
-
-    double getDeviceForce_N();
-    double getDeviceSpeed_kph();
 };
 
 #endif // _GC_FortiusController_h


### PR DESCRIPTION
Makes for cleaner lead-in-out code, focusses locking and makes unintentional access a little more obvious